### PR TITLE
Feature/speed up

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -20,7 +20,8 @@ def setup_input_output_paths(path_to_file):
     return path_to_input_file, path_to_output_file
 
 
-def validate_and_suggest_corrections(path_to_file=None):
+def validate_and_suggest_corrections(path_to_file=None,
+                                     column_to_update="university"):
     path_to_input_file, path_to_output_file = setup_input_output_paths(path_to_file)
 
     unmatched_entities = validate_csv_dataset(path_to_input_file,
@@ -30,7 +31,10 @@ def validate_and_suggest_corrections(path_to_file=None):
     # typos or non-standard entries.
 
     # First let's run the university standardiser
-    uploaded_names_df = pd.DataFrame({'uploaded_names': unmatched_entities['affiliationCurrent']})
+
+    uploaded_names_df = pd.DataFrame(
+        {'uploaded_names': unmatched_entities[column_to_update]}
+    )
     uploaded_names_df.to_csv('entries_to_fuzzy_match.csv')
 
     standardise_list('entries_to_fuzzy_match.csv',

--- a/driver.py
+++ b/driver.py
@@ -21,7 +21,7 @@ def setup_input_output_paths(path_to_file):
 
 
 def validate_and_suggest_corrections(path_to_file=None,
-                                     column_to_update="university"):
+                                     column_to_update="affiliationCurrent"):
     path_to_input_file, path_to_output_file = setup_input_output_paths(path_to_file)
 
     unmatched_entities = validate_csv_dataset(path_to_input_file,

--- a/driver.py
+++ b/driver.py
@@ -33,9 +33,9 @@ def validate_and_suggest_corrections(path_to_file=None):
     uploaded_names_df = pd.DataFrame({'uploaded_names': unmatched_entities['affiliationCurrent']})
     uploaded_names_df.to_csv('entries_to_fuzzy_match.csv')
 
-    matchedNames = standardise_list('entries_to_fuzzy_match.csv',
-                                    column_name_to_standardise='uploaded_names')
+    standardise_list('entries_to_fuzzy_match.csv',
+                     column_name_to_standardise='uploaded_names')
 
 
 if __name__ == "__main__":
-    errors_map = validate_and_suggest_corrections()
+    validate_and_suggest_corrections()

--- a/matcher/standardise.py
+++ b/matcher/standardise.py
@@ -1,4 +1,4 @@
-from fuzzywuzzy import process
+from fuzzywuzzy import process, fuzz
 from fuzzywuzzy.utils import full_process
 import pandas as pd
 import time
@@ -21,27 +21,56 @@ def standardise_name(uploaded_name, standard_univs):
         val = acronym_match.values[0]
         return val, 100, acronym_match.index[0]
 
-    # Alias matches
+    processed_name = full_process(uploaded_name, force_ascii=True)
 
-    alias_match = process.extractOne(uploaded_name, standard_univs['alias'])
-    full_name_match = process.extractOne(uploaded_name, standard_univs['Name'])
+
+    # Name match scores
+    standard_univs['full_name_similarity'] = standard_univs['Name'].apply(
+        lambda x: fuzz.ratio(processed_name, x)
+    )
+    full_name_match_idx = standard_univs['full_name_similarity'].nlargest(n=1, keep='all').index
+
+    full_name_matches = [
+        (row['Name'], row['full_name_similarity'], idx)
+        for idx, row in standard_univs.iloc[full_name_match_idx].iterrows()
+    ]
+
+    # Alias match scores
+    standard_univs['alias_similarity'] = standard_univs['alias'].apply(
+        lambda x: fuzz.ratio(processed_name, x)
+    )
+    alias_match_idx = standard_univs['alias_similarity'].nlargest(n=1, keep='all').index
+
+    # Looks weird to use row['name'] for alias
+    # but we want to return the name in the end
+    # We are comparing the correct similarity though.
+    alias_matches = [
+        (row['Name'], row['alias_similarity'], idx)
+        for idx, row in standard_univs.iloc[alias_match_idx].iterrows()
+    ]
 
     # The tuples - alias_match and full_name_match have three values -
     # (Name Matched, Confidence and Index Number in the standard list)
     # We are here comparing confidence between the full name match and the alias match
     # and returing the one with greater confidence.
 
-    if not alias_match and not full_name_match:
+    if len(alias_matches) == 0 or len(full_name_matches) == 0:
         print("No match for input name in our database")
         return ()
 
     # Since, the aim is to return standard names,
     # in case of an alias value name with higher confidence, we return the corresponding full name
 
-    if (len(alias_match) == 0 or alias_match[1] <= full_name_match[1]):
-        return full_name_match
+    # TODO: This is only returning the FIRST match. What if there are two
+    #  names with the same score?
+
+    print(alias_matches)
+    print(full_name_matches)
+
+    if len(alias_matches) == 0 or alias_matches[0][1] <= full_name_matches[0][1]:
+        return full_name_matches[0]
     else:
-        return (standard_univs.at[alias_match[2], 'Name'], alias_match[1], alias_match[2])
+        return alias_matches[0]
 
 
 def standardise_list(file, column_name_to_standardise='uploaded_names'):
@@ -57,9 +86,10 @@ def standardise_list(file, column_name_to_standardise='uploaded_names'):
     # Initialises list of universities
     standard_univs = initialise_standard_univ_list()
     # Processes list of universities
-    standard_univs['Name'] = standard_univs['Name'].apply(
-        lambda x: full_process(x, force_ascii=True)
-    )
+    for column in ['Name', 'alias']:
+        standard_univs[column] = standard_univs[column].apply(
+            lambda x: full_process(x, force_ascii=True)
+        )
 
     matched_names = [standardise_name(uploaded_name, standard_univs)
                      for uploaded_name in tqdm(uploaded_names)]

--- a/matcher/standardise.py
+++ b/matcher/standardise.py
@@ -23,7 +23,6 @@ def standardise_name(uploaded_name, standard_univs):
 
     processed_name = full_process(uploaded_name, force_ascii=True)
 
-
     # Name match scores
     standard_univs['full_name_similarity'] = standard_univs['Name'].apply(
         lambda x: fuzz.ratio(processed_name, x)

--- a/matcher/standardise.py
+++ b/matcher/standardise.py
@@ -25,7 +25,7 @@ def standardise_name(uploaded_name, standard_univs):
 
     # Name match scores
     standard_univs['full_name_similarity'] = standard_univs['Name'].apply(
-        lambda x: fuzz.ratio(processed_name, x)
+        lambda x: (fuzz.ratio(processed_name, x) if pd.notna(x) else 0)
     )
     full_name_match_idx = standard_univs['full_name_similarity'].nlargest(n=1, keep='all').index
 
@@ -36,7 +36,7 @@ def standardise_name(uploaded_name, standard_univs):
 
     # Alias match scores
     standard_univs['alias_similarity'] = standard_univs['alias'].apply(
-        lambda x: fuzz.ratio(processed_name, x)
+        lambda x: (fuzz.ratio(processed_name, x) if pd.notna(x) else 0)
     )
     alias_match_idx = standard_univs['alias_similarity'].nlargest(n=1, keep='all').index
 
@@ -62,9 +62,6 @@ def standardise_name(uploaded_name, standard_univs):
 
     # TODO: This is only returning the FIRST match. What if there are two
     #  names with the same score?
-
-    print(alias_matches)
-    print(full_name_matches)
 
     if len(alias_matches) == 0 or alias_matches[0][1] <= full_name_matches[0][1]:
         return full_name_matches[0]

--- a/matcher/standardise.py
+++ b/matcher/standardise.py
@@ -1,4 +1,5 @@
 from fuzzywuzzy import process
+from fuzzywuzzy.utils import full_process
 import pandas as pd
 import time
 from matcher.initialise_standard_univ_list import initialise_standard_univ_list
@@ -55,6 +56,10 @@ def standardise_list(file, column_name_to_standardise='uploaded_names'):
 
     # Initialises list of universities
     standard_univs = initialise_standard_univ_list()
+    # Processes list of universities
+    standard_univs['Name'] = standard_univs['Name'].apply(
+        lambda x: full_process(x, force_ascii=True)
+    )
 
     matched_names = [standardise_name(uploaded_name, standard_univs)
                      for uploaded_name in tqdm(uploaded_names)]

--- a/matcher/standardise.py
+++ b/matcher/standardise.py
@@ -11,14 +11,14 @@ def get_standard_univs_names():
     return standard_univs['Name']
 
 
-def standardise_name(uploaded_name):
-    standard_univs = initialise_standard_univ_list()
+def standardise_name(uploaded_name, standard_univs):
+    acronym_match = standard_univs.loc[
+        standard_univs['acronym'] == uploaded_name, 'Name'
+    ]
 
-    acronym_match = standard_univs.loc[standard_univs['acronym']
-                                == uploaded_name, 'Name']
     if not acronym_match.empty:
         val = acronym_match.values[0]
-        return (val, 100, acronym_match.index[0])
+        return val, 100, acronym_match.index[0]
 
     # Alias matches
 
@@ -52,7 +52,11 @@ def standardise_list(file, column_name_to_standardise='uploaded_names'):
         return pd.DataFrame()
 
     uploaded_names = uploaded_data[column_name_to_standardise].dropna().unique()
-    matched_names = [standardise_name(uploaded_name)
+
+    # Initialises list of universities
+    standard_univs = initialise_standard_univ_list()
+
+    matched_names = [standardise_name(uploaded_name, standard_univs)
                      for uploaded_name in tqdm(uploaded_names)]
 
     matched_names_df = convert_to_data_frame(matched_names, uploaded_names)

--- a/validator/validate_data.py
+++ b/validator/validate_data.py
@@ -48,7 +48,7 @@ def _safe_eval_items(input_dict):
             finally:
                 output_dict[key] = eval_value
 
-    return input_dict
+    return output_dict
 
 
 def validate_csv_dataset(path_to_file, log_file=None):

--- a/validator/validate_data.py
+++ b/validator/validate_data.py
@@ -48,7 +48,7 @@ def _safe_eval_items(input_dict):
             finally:
                 output_dict[key] = eval_value
 
-    return output_dict
+    return input_dict
 
 
 def validate_csv_dataset(path_to_file, log_file=None):

--- a/validator/validate_data.py
+++ b/validator/validate_data.py
@@ -29,9 +29,9 @@ def validate_json_instance(json_instance, UNMATCHED_ENTITIES):
         if 'enum' in error.absolute_schema_path:
             message = f"{error.instance} is not a valid value for schema " \
                       f"property ({error.absolute_schema_path[1]})"
+            UNMATCHED_ENTITIES[error.absolute_schema_path[1]].append(error.instance)
 
         errors.append(message)
-        UNMATCHED_ENTITIES[error.absolute_schema_path[1]].append(error.instance)
 
     return errors
 


### PR DESCRIPTION
Before speed up, used to take 80s for the test to run. Now:

```
Entries which were not matched 

 defaultdict(<class 'list'>, {'affiliationCurrent': ['Cambridge', 'IISc', 'Manchester', 'National', 'IITB'], 'currency': ['KIL', 'JKE', 'JKE', 'JKE'], 'countryCurrent': ['XX', 'INR', 'AUS']})
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:02<00:00,  1.79it/s]
[('cambridge intellectual property  united kingdom', 86, 93748), ('indian institute of science bangalore', 100, 1704), ('university of new hampshire at manchester', 83, 41178), ('national zoological park', 80, 62398), ('indian institute of technology bombay', 100, 11578)]
Total time taken for Fuzzy Matching - 3.8134548664093018 seconds
```